### PR TITLE
Removing futures from install_requires list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ with open("README.md", "r") as fh:
 install_requires = [
     "requests",
     "six",
-    "futures"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
futures is a Python 2 package. 
The concurrent.futures used in the vt_graph_api package is in the std library so there shouldn't be any need for this.