### PR TITLE
update repo name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ VirusTotal Graph API allows you programatically interact with VirusTotal dataset
 ## Installing the API
 Install VirusTotal Graph Python API.
 ```
-git clone https://github.com/VirusTotal/vt_graph_api
-cd vt_graph_api
+git clone https://github.com/VirusTotal/vt-graph-api
+cd vt-graph-api
 pip install . --user
 ```
 


### PR DESCRIPTION
Attempting to run `git clone https://github.com/VirusTotal/vt_graph_api` on my machine (Ubuntu 20.04.5 LTS, git version 2.39.0) produces the error  

```
remote: Repository not found.
fatal: repository 'https://github.com/VirusTotal/vt_graph_api/' not found
```

The issue is fixed if `vt-graph-api` is used instead. 